### PR TITLE
refactor!: move route composition to main (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,28 +114,25 @@ graph LR
     %% Test coverage
     tests[tests]
 
-    %% Core application flow
+    %% Module dependencies (solid arrows = imports)
+    main --> data
+    main --> service
+    main --> controller
     main --> route
+    main --> swagger
+    main --> docs
     route --> controller
     controller --> service
     service --> data
     data --> model
-
-    %% Dependency injection relationships
-    main --> data
-    main --> service
-    main --> controller
-
-    %% Supporting features connections
-    route --> docs
-    main --> swagger
-
-    %% External dependencies
-    controller --> gin
     data --> gorm
+    route --> gin
+    tests --> main
 
-    %% Test coverage
-    tests -.-> main
+    %% Runtime composition (dotted arrows = main creates/wires)
+    main -.-> gin
+    main -.-> service
+    main -.-> controller
 
     %% Node styling
     classDef core fill:#b3d9ff,stroke:#6db1ff,stroke-width:2px,color:#555,font-family:monospace;
@@ -149,7 +146,16 @@ graph LR
     class tests test
 ```
 
-Layered architecture: Core application flow (blue), supporting features (yellow), external dependencies (red), and test coverage (green). Dependencies are injected at startup, enabling better testability and separation of concerns.
+**Arrow Semantics:**
+
+- **Solid arrows** represent compile-time module dependencies (imports). For example, `controller → service` means the controller package imports and uses the service package.
+- **Dotted arrows** represent runtime composition. The `main` package creates instances (database connection, service, controller, Gin router) and wires them together at startup.
+
+**Composition Root Pattern:** The `main` package acts as the composition root, creating all dependencies and the Gin router instance. It registers player routes through the `route` package and adds Swagger/health routes directly. This pattern enables dependency injection, improves testability, and maintains clear separation of concerns.
+
+**Layered Architecture:** HTTP requests flow through distinct layers: `route` → `controller` → `service` → `data` → `model`. Each layer has a specific responsibility - routes handle HTTP mapping, controllers manage request/response, services contain business logic, data handles persistence, and models define data structures.
+
+**Color Coding:** Core packages (blue) implement the application logic, supporting features (yellow) provide documentation and utilities, external dependencies (red) are third-party frameworks and ORMs, and tests (green) ensure code quality.
 
 ## API Reference
 

--- a/route/player_route.go
+++ b/route/player_route.go
@@ -9,18 +9,10 @@ import (
 	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
 	"github.com/nanotaboada/go-samples-gin-restful/controller"
-	swaggerFiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
-// Setup configures the router Engine connecting URL paths with controller handlers
-func Setup(controller *controller.PlayerController) *gin.Engine {
-	store := persistence.NewInMemoryStore(time.Hour)
-
-	router := gin.Default()
-
-	router.GET(SwaggerPath, ginSwagger.WrapHandler(swaggerFiles.Handler))
-
+// RegisterPlayerRoutes configures player-related routes on the router
+func RegisterPlayerRoutes(router *gin.Engine, controller *controller.PlayerController, store *persistence.InMemoryStore) {
 	// Register routes for /players (without trailing slash)
 	router.GET(GetAllPath, cache.CachePage(store, time.Hour, controller.GetAll))
 	router.POST(GetAllPath, ClearCache(store, controller.Post))
@@ -33,12 +25,6 @@ func Setup(controller *controller.PlayerController) *gin.Engine {
 	router.GET(GetBySquadNumberPath, cache.CachePage(store, time.Hour, controller.GetBySquadNumber))
 	router.PUT(GetByIDPath, ClearCache(store, controller.Put))
 	router.DELETE(GetByIDPath, ClearCache(store, controller.Delete))
-
-	router.GET(HealthPath, func(c *gin.Context) {
-		c.JSON(200, gin.H{"status": "ok"})
-	})
-
-	return router
 }
 
 // ClearCache resets the cache when the collection is modified (POST, PUT, DELETE)


### PR DESCRIPTION
- Remove Setup() function from player_route.go
- Add RegisterPlayerRoutes() accepting router, controller, and store
- Move Swagger and health routes to main.go composition root
- Rename testController to playerController for clarity
- Consolidate test setup functions into single setupRouter()
- Update README architecture diagram with solid/dotted arrows

BREAKING CHANGE: route.Setup() replaced with route.RegisterPlayerRoutes()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/176)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health check endpoint for service monitoring and diagnostics.
  * Added Swagger UI endpoint for API documentation access.

* **Documentation**
  * Enhanced architecture documentation with updated module dependency diagrams and explanatory sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->