### PR TITLE
perf: drop ARM64 platform to reduce CD build time

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Remove linux/arm64 from Docker build platforms to align with original workflow behavior. ARM64 emulation via QEMU was causing 8+ minute build times. Reverting to linux/amd64 only reduces builds to ~1-2 minutes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/187)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker image builds now only support the linux/amd64 platform. Support for linux/arm64 has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->