### PR TITLE
docs(readme): normalize README structure

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -13,36 +13,16 @@
 ![Claude](https://img.shields.io/badge/Claude-contributing-D97757?logo=claude&logoColor=white&labelColor=181818)
 ![CodeRabbit](https://img.shields.io/badge/CodeRabbit-reviewing-FF570A?logo=coderabbit&logoColor=white&labelColor=181818)
 
-Proof of Concept for a RESTful API built with [Go](https://github.com/golang/go) and [Gin](https://github.com/gin-gonic/gin). Manage football player data with SQLite, GORM, Swagger documentation, and in-memory caching.
-
-## Table of Contents
-
-- [Features](#features)
-- [Tech Stack](#tech-stack)
-- [Project Structure](#project-structure)
-- [Architecture](#architecture)
-- [Architecture Decisions](#architecture-decisions)
-- [API Reference](#api-reference)
-- [Prerequisites](#prerequisites)
-- [Quick Start](#quick-start)
-- [Testing](#testing)
-- [Containers](#containers)
-- [Releases](#releases)
-- [Environment Variables](#environment-variables)
-- [Command Summary](#command-summary)
-- [Contributing](#contributing)
-- [Legal](#legal)
+Proof of Concept for a RESTful Web Service built with **Gin** and **Go 1.25**. This project demonstrates best practices for building a layered, testable, and maintainable API implementing CRUD operations for a Players resource (Argentina 2022 FIFA World Cup squad).
 
 ## Features
 
-- 🏗️ **Idiomatic Go patterns** - Clean architecture with middleware, dependency injection, and concurrency safety
-- 📚 **Interactive API exploration** - Auto-generated Swagger docs with `.rest` file, REST Client integration, and health monitoring
-- ⚡ **Performance optimizations** - In-memory caching, connection pooling, and efficient GORM queries
-- 🧪 **Comprehensive integration tests** - Full endpoint coverage with automated reporting to Codecov and SonarCloud
-- 📖 **Token-efficient documentation** - Auto-loaded Copilot instructions for AI-assisted development
-- 🐳 **Full containerization** - Optimized Docker builds with Docker Compose orchestration
-- 🔄 **Complete CI/CD pipeline** - Automated testing with race detection, Docker publishing, and GitHub releases
-- 🎖️ **Player-themed semantic versioning** - Memorable, alphabetical release names honoring football legends
+- 🏗️ **Layered Architecture** - Idiomatic Go with interface-based contracts and constructor injection
+- 📚 **Interactive Documentation** - Auto-generated Swagger UI with VS Code and JetBrains REST Client support
+- ⚡ **Performance Caching** - In-memory response caching via gin-contrib/cache with GORM
+- 🚦 **Comprehensive Testing** - Full endpoint coverage with testify, race detector, and automated reporting to Codecov
+- 🐳 **Containerized Deployment** - Multi-stage Docker builds with pre-seeded database
+- 🔄 **Automated Pipeline** - Continuous integration with race detector, Docker publishing, and GitHub releases
 
 ## Tech Stack
 
@@ -56,44 +36,6 @@ Proof of Concept for a RESTful API built with [Go](https://github.com/golang/go)
 | **API Documentation** | [Swagger/OpenAPI](https://github.com/swaggo/swag) |
 | **Testing** | [testify](https://github.com/stretchr/testify) |
 | **Containerization** | [Docker](https://github.com/docker) & [Docker Compose](https://github.com/docker/compose) |
-
-## Project Structure
-
-```tree
-/
-├── main.go                 # Entry point: DB connection, route setup, server start
-├── controller/             # HTTP handlers (request/response logic)
-│   └── player_controller.go
-├── service/                # Business logic (ORM interactions)
-│   └── player_service.go
-├── route/                  # Route configuration and middleware
-│   ├── player_route.go     # Route setup with caching middleware
-│   └── path.go             # Path constants
-├── model/                  # Data structures
-│   └── player_model.go
-├── data/                   # Database connection
-│   └── player_data.go
-├── swagger/                # Swagger configuration
-│   └── swagger.go
-├── docs/                   # Documentation
-│   ├── adr/                # Architecture Decision Records
-│   ├── docs.go             # Auto-generated Swagger docs (DO NOT EDIT)
-│   ├── swagger.json
-│   └── swagger.yaml
-├── tests/                  # Integration tests
-│   ├── main_test.go
-│   ├── mock_service.go
-│   ├── player_fake.go
-│   └── players.json
-├── tools/                  # Database seed scripts
-│   ├── seed_001_starting_eleven.go
-│   └── seed_002_substitutes.go
-├── rest/                   # HTTP request files
-│   └── players.rest        # CRUD requests (REST Client / JetBrains HTTP Client)
-├── storage/                # SQLite database file (pre-seeded)
-├── scripts/                # Container entrypoint & healthcheck
-└── .github/workflows/      # CI/CD pipelines
-```
 
 ## Architecture
 
@@ -172,58 +114,29 @@ graph RL
     class tests test
 ```
 
-### Arrow Semantics
+> *Arrows follow the injection direction (A → B means A is injected into B). Solid = runtime dependency, dotted = structural. Blue = core domain, yellow = support, red = third-party, green = tests.*
 
-Arrows follow the wiring direction: `A --> B` means A is provided to B. Solid arrows (`-->`) represent active dependencies — packages explicitly wired in `main` and invoked at runtime. Dotted arrows (`-.->`) represent structural dependencies — the consumer references types or function signatures without invoking runtime behavior.
-
-### Composition Root Pattern
-
-`main` is the composition root: it instantiates all dependencies, creates the Gin router, initializes the database connection, and registers all routes. No other package bears responsibility for wiring.
-
-### Layered Architecture
-
-Four layers: Initialization (`main`, `docs`, `swagger`), HTTP (`route`, `controller`), Business (`service`), and Data (`data`).
-
-External packages are placed inside the subgraph of the layer that uses them — `Gin` in HTTP, `GORM` in Data.
-
-`model` is a cross-cutting type concern — shared data structures consumed across all layers, with no logic of its own.
-
-### Color Coding
-
-Blue = core application packages, yellow = documentation and utility packages, red = third-party frameworks, green = tests.
-
-*Simplified, conceptual project structure and main application flow. Not all dependencies are shown.*
-
-## Architecture Decisions
-
-Significant architectural decisions — the alternatives considered, the choice made, and the trade-offs accepted — are documented as [Architecture Decision Records](docs/adr/README.md) in `docs/adr/`. Each ADR is an append-only record; when a decision changes, a new ADR is added rather than editing the original.
+Significant architectural decisions are documented in [`docs/adr/`](docs/adr/).
 
 ## API Reference
 
 Interactive API documentation is available via Swagger UI at `http://localhost:9000/swagger/index.html` when the server is running.
 
-> 💡 The Swagger documentation is automatically generated from code annotations using [swaggo/swag](https://github.com/swaggo/swag). To regenerate after making changes, run `swag init`.
+| Method | Endpoint | Description | Status |
+| ------ | -------- | ----------- | ------ |
+| `GET` | `/players` | List all players | `200 OK` |
+| `GET` | `/players/:id` | Get player by ID | `200 OK` |
+| `GET` | `/players/squadnumber/:squadnumber` | Get player by squad number | `200 OK` |
+| `POST` | `/players` | Create new player | `201 Created` |
+| `PUT` | `/players/squadnumber/:squadnumber` | Update player by squad number | `204 No Content` |
+| `DELETE` | `/players/squadnumber/:squadnumber` | Remove player by squad number | `204 No Content` |
+| `GET` | `/health` | Health check | `200 OK` |
 
-**Quick Reference:**
-
-- `GET /players` — List all players
-- `GET /players/:id` — Get player by UUID (surrogate key)
-- `GET /players/squadnumber/:squadnumber` — Get player by squad number (natural key)
-- `POST /players` — Create new player
-- `PUT /players/squadnumber/:squadnumber` — Update player by squad number
-- `DELETE /players/squadnumber/:squadnumber` — Remove player by squad number
-- `GET /health` — Health check
+Error codes: `400 Bad Request` (validation failed) · `404 Not Found` (player not found) · `409 Conflict` (duplicate squad number on `POST`)
 
 For complete endpoint documentation with request/response schemas, explore the [interactive Swagger UI](http://localhost:9000/swagger/index.html). You can also access the OpenAPI JSON specification at `http://localhost:9000/swagger.json`.
 
-### HTTP Requests
-
-A ready-to-use HTTP request file is available at [`rest/players.rest`](rest/players.rest). It covers all CRUD operations and can be run directly from your editor without leaving the development environment:
-
-- **VS Code** — install the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension (`humao.rest-client`), open `rest/players.rest`, and click **Send Request** above any entry.
-- **JetBrains IDEs** (IntelliJ IDEA, GoLand, WebStorm) — the built-in HTTP Client supports `.rest` files natively; no plugin required.
-
-The file targets `http://localhost:9000` by default (configurable via the `@baseUrl` variable at the top of the file).
+Alternatively, use [`rest/players.rest`](rest/players.rest) with the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension for VS Code, or the built-in HTTP Client in JetBrains IDEs (IntelliJ IDEA, GoLand, WebStorm).
 
 ## Prerequisites
 
@@ -234,167 +147,56 @@ Before you begin, ensure you have the following installed:
 
 ## Quick Start
 
-### Clone the repository
+### Clone
 
 ```bash
 git clone https://github.com/nanotaboada/go-samples-gin-restful.git
 cd go-samples-gin-restful
 ```
 
-### Install dependencies
+### Install
 
 ```bash
 go mod download
 ```
 
-### Start the development server
+### Run
 
 ```bash
 go run .
 ```
 
-The server will start on `http://localhost:9000`.
+### Access
 
-### Access the application
+Once the application is running, you can access:
 
-- **API:** `http://localhost:9000`
-- **Swagger Documentation:** `http://localhost:9000/swagger/index.html`
-- **Health Check:** `http://localhost:9000/health`
-
-## Testing
-
-Run the test suite with coverage:
-
-```bash
-# Run all tests
-go test ./...
-
-# Run tests with coverage
-go test -v ./... -coverprofile=coverage.out
-
-# Run tests with detailed coverage for specific packages
-go test -v ./... \
-  -coverpkg=github.com/nanotaboada/go-samples-gin-restful/service,github.com/nanotaboada/go-samples-gin-restful/controller,github.com/nanotaboada/go-samples-gin-restful/route \
-  -covermode=atomic \
-  -coverprofile=coverage.out
-
-# View coverage report
-go tool cover -html=coverage.out
-```
-
-Tests are located in the `tests/` directory and use testify for integration testing. Coverage reports are generated for controllers, services, and routes only.
-
-**Coverage targets:** 80% minimum for service, controller, and route packages.
+- **API Server**: `http://localhost:9000`
+- **Swagger UI**: `http://localhost:9000/swagger/index.html`
+- **Health Check**: `http://localhost:9000/health`
 
 ## Containers
 
-This project includes full Docker support with multi-stage builds and Docker Compose for easy deployment.
-
-### Build the Docker image
-
-```bash
-docker compose build
-```
-
-### Start the application
+### Build and Start
 
 ```bash
 docker compose up
 ```
 
-> 💡 On first run, the container copies a pre-seeded SQLite database into a persistent volume. On subsequent runs, that volume is reused and the data is preserved.
+> 💡 **Note:** On first run, the container copies a pre-seeded SQLite database into a persistent volume. On subsequent runs, that volume is reused and the data is preserved.
 
-### Stop the application
+### Stop
 
 ```bash
 docker compose down
 ```
 
-### Reset the database
+### Reset Database
 
 To remove the volume and reinitialize the database from the built-in seed file:
 
 ```bash
 docker compose down -v
 ```
-
-The containerized application runs on port 9000 and includes health checks that monitor the `/health` endpoint every 30 seconds.
-
-## Releases
-
-This project uses famous football players as release codenames 🎖️, inspired by Ubuntu, Android, and macOS naming conventions.
-
-### Release Naming Convention
-
-Releases follow the pattern: `v{SEMVER}-{PLAYER}` (e.g., `v1.0.0-ademir`)
-
-- **Semantic Version**: Standard versioning (MAJOR.MINOR.PATCH)
-- **Player Name**: Alphabetically ordered codename from the [famous player list](CHANGELOG.md#famous-football-player-names-️)
-
-### Create a Release
-
-To create a new release, follow this workflow:
-
-#### 1. Create a Release Branch
-
-Branch protection prevents direct pushes to `master`, so all release prep goes through a PR:
-
-```bash
-git checkout master && git pull
-git checkout -b release/vX.Y.Z-player
-```
-
-#### 2. Update CHANGELOG.md
-
-Move items from `[Unreleased]` to a new release section in [CHANGELOG.md](CHANGELOG.md), then commit and push the branch:
-
-```bash
-# Move items from [Unreleased] to new release section
-# Example: [2.0.0 - Bobby] - 2026-03-19
-git add CHANGELOG.md
-git commit -m "docs(changelog): prepare release notes for vX.Y.Z-player"
-git push origin release/vX.Y.Z-player
-```
-
-#### 3. Merge the Release PR
-
-Open a pull request from `release/vX.Y.Z-player` into `master` and merge it. The tag must be created **after** the merge so it points to the correct commit on `master`.
-
-#### 4. Create and Push Tag
-
-After the PR is merged, pull `master` and create the annotated tag:
-
-```bash
-git checkout master && git pull
-git tag -a vX.Y.Z-player -m "Release X.Y.Z - Player"
-git push origin vX.Y.Z-player
-```
-
-Example:
-
-```bash
-git tag -a v2.0.0-bobby -m "Release 2.0.0 - Bobby"
-git push origin v2.0.0-bobby
-```
-
-#### 5. Automated CD Workflow
-
-This triggers the CD workflow which automatically:
-
-1. Validates the player name
-2. Builds and tests the project with race detector
-3. Publishes Docker images to GitHub Container Registry with three tags
-4. Creates a GitHub Release with auto-generated changelog from commits
-
-#### Pre-Release Checklist
-
-- [ ] Release branch created from `master`
-- [ ] `CHANGELOG.md` updated with release notes
-- [ ] Changes committed and pushed on the release branch
-- [ ] Release PR merged into `master`
-- [ ] Tag created with correct format: `vX.Y.Z-player`
-- [ ] Player name is valid (A-Z from the [famous player list](CHANGELOG.md#famous-football-player-names-️))
-- [ ] Tag pushed to trigger CD workflow
 
 ### Pull Docker Images
 
@@ -411,20 +213,46 @@ docker pull ghcr.io/nanotaboada/go-samples-gin-restful:ademir
 docker pull ghcr.io/nanotaboada/go-samples-gin-restful:latest
 ```
 
-> 💡 See [CHANGELOG.md](CHANGELOG.md) for the complete player list (A-Z) and release history.
-
 ## Environment Variables
-
-The application can be configured using the following environment variables (declared in [`compose.yaml`](https://github.com/nanotaboada/go-samples-gin-restful/blob/master/compose.yaml)):
 
 ```bash
 # Database storage path (default: ./storage/players-sqlite3.db)
-# In Docker: /storage/players-sqlite3.db
 STORAGE_PATH=./storage/players-sqlite3.db
 
 # Gin framework mode: debug, release, or test (default: debug)
-# In Docker: release
 GIN_MODE=release
+```
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on:
+
+- Code of Conduct
+- Development workflow and best practices
+- Commit message conventions (Conventional Commits)
+- Pull request process and requirements
+
+**Key guidelines:**
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+- Ensure all tests pass (`go test ./...`)
+- Run `go fmt ./...` before committing
+- Keep changes small and focused
+- Review `.github/copilot-instructions.md` for architectural patterns
+
+**Testing:**
+
+Run the test suite with testify:
+
+```bash
+# Run all tests
+go test ./...
+
+# Run tests with coverage
+go test -v ./... \
+  -coverpkg=github.com/nanotaboada/go-samples-gin-restful/service,github.com/nanotaboada/go-samples-gin-restful/controller,github.com/nanotaboada/go-samples-gin-restful/route \
+  -covermode=atomic \
+  -coverprofile=coverage.out
 ```
 
 ## Command Summary
@@ -434,7 +262,7 @@ GIN_MODE=release
 | `go run .` | Start development server |
 | `go build` | Build the application |
 | `go test ./...` | Run all tests |
-| `go test -v ./... -coverpkg=github.com/nanotaboada/go-samples-gin-restful/service,github.com/nanotaboada/go-samples-gin-restful/controller,github.com/nanotaboada/go-samples-gin-restful/route -covermode=atomic -coverprofile=coverage.out` | Run tests with coverage |
+| `go test -v ./... -covermode=atomic -coverprofile=coverage.out` | Run tests with coverage |
 | `go tool cover -html=coverage.out` | View coverage report |
 | `go fmt ./...` | Format code |
 | `go mod tidy` | Clean up dependencies |
@@ -444,17 +272,9 @@ GIN_MODE=release
 | `docker compose up` | Start Docker container |
 | `docker compose down` | Stop Docker container |
 | `docker compose down -v` | Stop and remove Docker volume |
-
-## Contributing
-
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on the code of conduct and the process for submitting pull requests.
-
-**Key guidelines:**
-
-- Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
-- Ensure all tests pass (`go test ./...`)
-- Run `go fmt` before committing
-- Keep changes small and focused
+| **AI Commands** | |
+| `/pre-commit` | Runs linting, tests, and quality checks before committing |
+| `/pre-release` | Runs pre-release validation workflow |
 
 ## Legal
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,74 @@
+# Releases
+
+Releases follow the pattern `v{SEMVER}-{PLAYER}` (e.g., `v1.0.0-ademir`). Codenames are drawn alphabetically from the [famous player list](CHANGELOG.md).
+
+## Workflow
+
+### 1. Create a Release Branch
+
+Branch protection prevents direct pushes to `master`, so all release prep goes through a PR:
+
+```bash
+git checkout master && git pull
+git checkout -b release/v1.0.0-ademir
+```
+
+### 2. Update CHANGELOG.md
+
+Move items from `[Unreleased]` to a new release section in [CHANGELOG.md](CHANGELOG.md), then commit and push the branch:
+
+```bash
+# Move items from [Unreleased] to new release section
+# Example: [1.0.0 - Ademir] - 2026-XX-XX
+git add CHANGELOG.md
+git commit -m "docs(changelog): prepare release notes for v1.0.0-ademir"
+git push origin release/v1.0.0-ademir
+```
+
+### 3. Merge the Release PR
+
+Open a pull request from `release/v1.0.0-ademir` into `master` and merge it. The tag must be created **after** the merge so it points to the correct commit on `master`.
+
+### Pre-release Checklist
+
+Before creating the tag, verify all of the following:
+
+- [ ] `CHANGELOG.md` `[Unreleased]` section is moved to a new versioned release entry
+- [ ] Release PR is merged into `master`
+- [ ] `go test ./...` passes
+- [ ] Player name is valid and follows alphabetical order (see "Famous Football Player Names" in [CHANGELOG.md](CHANGELOG.md))
+- [ ] All CI checks on `master` are green
+
+### 4. Create and Push Tag
+
+After the PR is merged, pull `master` and create the annotated tag:
+
+```bash
+git checkout master && git pull
+git tag -a v1.0.0-ademir -m "Release 1.0.0 - Ademir"
+git push origin v1.0.0-ademir
+```
+
+### 5. Automated CD Workflow
+
+Pushing the tag triggers the CD workflow which automatically:
+
+1. Validates tag format (semver and player name)
+2. Builds and tests the project with race detector
+3. Publishes Docker images to GitHub Container Registry with three tags
+4. Creates a GitHub Release with auto-generated changelog from commits
+
+## Docker Pull
+
+Each release publishes multiple tags for flexibility:
+
+```bash
+# By semantic version (recommended for production)
+docker pull ghcr.io/nanotaboada/go-samples-gin-restful:1.0.0
+
+# By player name (memorable alternative)
+docker pull ghcr.io/nanotaboada/go-samples-gin-restful:ademir
+
+# Latest release
+docker pull ghcr.io/nanotaboada/go-samples-gin-restful:latest
+```


### PR DESCRIPTION
Closes #242

## Summary

- Removed Table of Contents, Project Structure, Testing, Releases, and Architecture Decisions sections
- Features trimmed to 6 bullets (dropped testing/AI-tooling/versioning; added Comprehensive Testing with testify + race detector)
- Architecture prose subsections replaced with 2-line callout + ADR one-liner; callout notes yellow = support for the Go-specific `docs`/`swagger` layer
- API Reference converted to unified `Method | Endpoint | Description | Status` table; routes verified against source
- Quick Start subheadings aligned with sibling repos (Clone / Install / Run / Access)
- Containers: added Docker pull block, removed redundant prose
- Contributing: absorbed testing instructions; moved before Command Summary
- Command Summary: simplified coverage command, added AI Commands subsection
- New files: `RELEASES.md`, `.markdownlint.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/243)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * README restructured with condensed content focusing on core features, API reference, and contributing guidelines
  * New release process documentation added outlining version naming, release workflow, and CI/CD automation

* **Chores**
  * Added markdown linting configuration for improved documentation quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->