### PR TITLE
feat(validation): field-level validation, return 422 on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,15 @@ This project uses famous football player names (A-Z) as release codenames:
 
 ### Added
 
+- `model/player_model.go`: added `binding` struct tags to `Player` for field-level validation via Gin's built-in validator (`go-playground/validator`) — required fields: `firstName`, `lastName`, `dateOfBirth`, `position`, `abbrPosition`, `team`, `league`; range constraint on `squadNumber` (`min=1,max=99`); `omitempty` on `middleName`; `binding:"-"` on `ID` (#257)
+- `controller/player_controller.go`: POST and PUT handlers now return `422 Unprocessable Entity` for validation failures and `400 Bad Request` for malformed JSON, distinguished via `errors.As(err, &validator.ValidationErrors{})` (#257)
+- `tests/main_test.go`: added `TestRequestPOSTPlayersValidationResponseStatusUnprocessableEntity` and `TestRequestPUTPlayerBySquadNumberValidationResponseStatusUnprocessableEntity` table-driven tests covering missing required fields and out-of-range `squadNumber` (#257)
+
 ### Changed
+
+- `tests/player_fake.go`: `MakeUnknownPlayer()` now returns a fully populated player so PUT 404-by-lookup tests pass binding validation before reaching the service layer (#257)
+- `controller/player_controller.go`: replaced `BindJSON` with `ShouldBindJSON` in Post and Put handlers to take full control over error responses (#257)
+- `docs/`: regenerated Swagger docs (`swag init`) to include `@Failure 422 "Unprocessable Entity"` on POST and PUT endpoints (#257)
 
 ### Removed
 

--- a/controller/player_controller.go
+++ b/controller/player_controller.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/nanotaboada/go-samples-gin-restful/model"
 	"github.com/nanotaboada/go-samples-gin-restful/service"
@@ -56,15 +57,22 @@ func isUniqueConstraintError(err error) bool {
 // @Success 201 "Created"
 // @Failure 400 "Bad Request"
 // @Failure 409 "Conflict"
+// @Failure 422 "Unprocessable Entity"
 // @Failure 500 "Internal Server Error"
 // @Router /players [post]
 func (c *PlayerController) Post(context *gin.Context) {
 	var player model.Player
-	// BindJSON deserialises the request body into the struct and validates
-	// required fields declared with the `binding:"required"` tag.  On failure
-	// it writes a 400 response automatically; we still return to stop execution.
-	if err := context.BindJSON(&player); err != nil {
-		context.Status(http.StatusBadRequest)
+	// ShouldBindJSON deserialises the request body without writing a response
+	// automatically, giving us full control over the status code.
+	// validator.ValidationErrors signals a field-level constraint failure → 422.
+	// Any other error (EOF, syntax) is a malformed request → 400.
+	if err := context.ShouldBindJSON(&player); err != nil {
+		var ve validator.ValidationErrors
+		if errors.As(err, &ve) {
+			context.Status(http.StatusUnprocessableEntity)
+		} else {
+			context.Status(http.StatusBadRequest)
+		}
 		return
 	}
 	// UUID is always generated server-side; any client-provided ID is overwritten.
@@ -183,6 +191,7 @@ func (c *PlayerController) GetBySquadNumber(context *gin.Context) {
 // @Success 204 "No Content"
 // @Failure 400 "Bad Request"
 // @Failure 404 "Not Found"
+// @Failure 422 "Unprocessable Entity"
 // @Failure 500 "Internal Server Error"
 // @Router /players/squadnumber/{squadnumber} [put]
 func (c *PlayerController) Put(context *gin.Context) {
@@ -192,9 +201,20 @@ func (c *PlayerController) Put(context *gin.Context) {
 		return
 	}
 	var player model.Player
+	// ShouldBindJSON gives us control over the response code.
+	// validator.ValidationErrors → 422; parse/syntax errors → 400.
+	if err = context.ShouldBindJSON(&player); err != nil {
+		var ve validator.ValidationErrors
+		if errors.As(err, &ve) {
+			context.Status(http.StatusUnprocessableEntity)
+		} else {
+			context.Status(http.StatusBadRequest)
+		}
+		return
+	}
 	// Guard against mismatched URL and body: the squad number in the URL must
 	// equal the one in the JSON body, otherwise the request is ambiguous → 400.
-	if err = context.BindJSON(&player); err != nil || player.SquadNumber != squadNumber {
+	if player.SquadNumber != squadNumber {
 		context.Status(http.StatusBadRequest)
 		return
 	}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -68,6 +68,9 @@ const docTemplate = `{
                     "409": {
                         "description": "Conflict"
                     },
+                    "422": {
+                        "description": "Unprocessable Entity"
+                    },
                     "500": {
                         "description": "Internal Server Error"
                     }
@@ -146,6 +149,9 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found"
                     },
+                    "422": {
+                        "description": "Unprocessable Entity"
+                    },
                     "500": {
                         "description": "Internal Server Error"
                     }
@@ -219,6 +225,15 @@ const docTemplate = `{
     "definitions": {
         "model.Player": {
             "type": "object",
+            "required": [
+                "abbrPosition",
+                "dateOfBirth",
+                "firstName",
+                "lastName",
+                "league",
+                "position",
+                "team"
+            ],
             "properties": {
                 "abbrPosition": {
                     "description": "The abbreviated form of the Player's position",
@@ -254,7 +269,9 @@ const docTemplate = `{
                 },
                 "squadNumber": {
                     "description": "User-facing unique identifier; DB-enforced uniqueness",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 99,
+                    "minimum": 1
                 },
                 "starting11": {
                     "description": "Indicates whether the Player is in the starting 11",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -57,6 +57,9 @@
                     "409": {
                         "description": "Conflict"
                     },
+                    "422": {
+                        "description": "Unprocessable Entity"
+                    },
                     "500": {
                         "description": "Internal Server Error"
                     }
@@ -135,6 +138,9 @@
                     "404": {
                         "description": "Not Found"
                     },
+                    "422": {
+                        "description": "Unprocessable Entity"
+                    },
                     "500": {
                         "description": "Internal Server Error"
                     }
@@ -208,6 +214,15 @@
     "definitions": {
         "model.Player": {
             "type": "object",
+            "required": [
+                "abbrPosition",
+                "dateOfBirth",
+                "firstName",
+                "lastName",
+                "league",
+                "position",
+                "team"
+            ],
             "properties": {
                 "abbrPosition": {
                     "description": "The abbreviated form of the Player's position",
@@ -243,7 +258,9 @@
                 },
                 "squadNumber": {
                     "description": "User-facing unique identifier; DB-enforced uniqueness",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 99,
+                    "minimum": 1
                 },
                 "starting11": {
                     "description": "Indicates whether the Player is in the starting 11",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -27,6 +27,8 @@ definitions:
         type: string
       squadNumber:
         description: User-facing unique identifier; DB-enforced uniqueness
+        maximum: 99
+        minimum: 1
         type: integer
       starting11:
         description: Indicates whether the Player is in the starting 11
@@ -34,6 +36,14 @@ definitions:
       team:
         description: The team to which the Player belongs
         type: string
+    required:
+    - abbrPosition
+    - dateOfBirth
+    - firstName
+    - lastName
+    - league
+    - position
+    - team
     type: object
 info:
   contact: {}
@@ -71,6 +81,8 @@ paths:
           description: Bad Request
         "409":
           description: Conflict
+        "422":
+          description: Unprocessable Entity
         "500":
           description: Internal Server Error
       summary: Creates a Player
@@ -163,6 +175,8 @@ paths:
           description: Bad Request
         "404":
           description: Not Found
+        "422":
+          description: Unprocessable Entity
         "500":
           description: Internal Server Error
       summary: Updates (entirely) a Player by its Squad Number

--- a/model/player_model.go
+++ b/model/player_model.go
@@ -6,7 +6,7 @@ package model
 //
 // # Struct tags
 //
-// Each field carries two sets of struct tags that Go reads at runtime via
+// Each field carries three sets of struct tags that Go reads at runtime via
 // reflection:
 //
 //   - `json:"..."` — controls marshalling to/from JSON.
@@ -19,6 +19,11 @@ package model
 //     the type is string — UUIDs are assigned by the application, not the DB).
 //     `uniqueIndex` creates a unique index in SQLite, enforced at the DB level.
 //
+//   - `binding:"..."` — controls Gin's request binding validation (backed by
+//     go-playground/validator).  `required` rejects zero/empty values; `min`
+//     and `max` enforce numeric ranges; `omitempty` skips validation when the
+//     field is absent; `-` excludes the field from binding entirely.
+//
 // # ID design
 //
 // ID is a string (not an integer auto-increment) because it stores a UUID v4,
@@ -26,15 +31,15 @@ package model
 // across environments.  Clients use squadNumber to identify players in PUT and
 // DELETE requests; the UUID is available via the UUID lookup endpoint.
 type Player struct {
-	ID           string `json:"id" gorm:"column:id;primaryKey"`                    // Internal UUID (server-generated, opaque to clients)
-	FirstName    string `json:"firstName" gorm:"column:firstName"`                 // The first name of the Player
-	MiddleName   string `json:"middleName" gorm:"column:middleName"`               // The middle name of the Player, if any
-	LastName     string `json:"lastName" gorm:"column:lastName"`                   // The last name of the Player
-	DateOfBirth  string `json:"dateOfBirth" gorm:"column:dateOfBirth"`             // The date of birth of the Player
-	SquadNumber  int    `json:"squadNumber" gorm:"column:squadNumber;uniqueIndex"` // User-facing unique identifier; DB-enforced uniqueness
-	Position     string `json:"position" gorm:"column:position"`                   // The playing position of the Player
-	AbbrPosition string `json:"abbrPosition" gorm:"column:abbrPosition"`           // The abbreviated form of the Player's position
-	Team         string `json:"team" gorm:"column:team"`                           // The team to which the Player belongs
-	League       string `json:"league" gorm:"column:league"`                       // The league where the team plays
-	Starting11   bool   `json:"starting11" gorm:"column:starting11"`               // Indicates whether the Player is in the starting 11
+	ID           string `json:"id" gorm:"column:id;primaryKey" binding:"-"`                               // Internal UUID (server-generated, opaque to clients)
+	FirstName    string `json:"firstName" gorm:"column:firstName" binding:"required"`                     // The first name of the Player
+	MiddleName   string `json:"middleName" gorm:"column:middleName" binding:"omitempty"`                  // The middle name of the Player, if any
+	LastName     string `json:"lastName" gorm:"column:lastName" binding:"required"`                       // The last name of the Player
+	DateOfBirth  string `json:"dateOfBirth" gorm:"column:dateOfBirth" binding:"required"`                 // The date of birth of the Player
+	SquadNumber  int    `json:"squadNumber" gorm:"column:squadNumber;uniqueIndex" binding:"min=1,max=99"` // User-facing unique identifier; DB-enforced uniqueness
+	Position     string `json:"position" gorm:"column:position" binding:"required"`                       // The playing position of the Player
+	AbbrPosition string `json:"abbrPosition" gorm:"column:abbrPosition" binding:"required"`               // The abbreviated form of the Player's position
+	Team         string `json:"team" gorm:"column:team" binding:"required"`                               // The team to which the Player belongs
+	League       string `json:"league" gorm:"column:league" binding:"required"`                           // The league where the team plays
+	Starting11   bool   `json:"starting11" gorm:"column:starting11"`                                      // Indicates whether the Player is in the starting 11
 }

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -113,6 +113,7 @@ func buildSquadNumberPath(squadNumber string) string {
 // GET request to /health
 // returns a 200 OK status, indicating the server is running and healthy.
 func TestRequestGETHealthResponseStatusOK(test *testing.T) {
+
 	// Arrange
 	router := setupRouter(playerController)
 	recorder := httptest.NewRecorder()
@@ -134,6 +135,7 @@ func TestRequestGETHealthResponseStatusOK(test *testing.T) {
 // POST request to /players with an empty body
 // returns a 400 Bad Request status.
 func TestRequestPOSTPlayersEmptyBodyResponseStatusBadRequest(test *testing.T) {
+
 	// Arrange
 	router := setupRouter(playerController)
 	recorder := httptest.NewRecorder()
@@ -154,6 +156,7 @@ func TestRequestPOSTPlayersEmptyBodyResponseStatusBadRequest(test *testing.T) {
 // POST request to /players with an existing player
 // returns a 409 Conflict status.
 func TestRequestPOSTPlayersExistingResponseStatusConflict(test *testing.T) {
+
 	// Arrange
 	player := MakeExistingPlayer()
 	body, err := json.Marshal(player)
@@ -179,6 +182,7 @@ func TestRequestPOSTPlayersExistingResponseStatusConflict(test *testing.T) {
 // POST request to /players with a non-existing player
 // returns a 201 Created status.
 func TestRequestPOSTPlayersNonExistingResponseStatusCreated(test *testing.T) {
+
 	// Arrange
 	player := MakeNonexistentPlayer()
 	body, err := json.Marshal(player)
@@ -200,10 +204,68 @@ func TestRequestPOSTPlayersNonExistingResponseStatusCreated(test *testing.T) {
 	assert.Equal(test, http.StatusCreated, recorder.Code)
 }
 
+// TestRequestPOSTPlayersValidationResponseStatusUnprocessableEntity tests that a
+// POST request to /players with an invalid payload (missing required fields or
+// out-of-range squadNumber) returns a 422 Unprocessable Entity status.
+func TestRequestPOSTPlayersValidationResponseStatusUnprocessableEntity(test *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			"MissingRequiredFieldResponseStatusUnprocessableEntity",
+			func() string {
+				p := MakeNonexistentPlayer()
+				p.FirstName = ""
+				b, _ := json.Marshal(p)
+				return string(b)
+			}(),
+		},
+		{
+			"SquadNumberBelowMinResponseStatusUnprocessableEntity",
+			func() string {
+				p := MakeNonexistentPlayer()
+				p.SquadNumber = 0
+				b, _ := json.Marshal(p)
+				return string(b)
+			}(),
+		},
+		{
+			"SquadNumberAboveMaxResponseStatusUnprocessableEntity",
+			func() string {
+				p := MakeNonexistentPlayer()
+				p.SquadNumber = 100
+				b, _ := json.Marshal(p)
+				return string(b)
+			}(),
+		},
+	}
+	for _, tc := range cases {
+		test.Run(tc.name, func(t *testing.T) {
+
+			// Arrange
+			router := setupRouter(playerController)
+			recorder := httptest.NewRecorder()
+			request, err := http.NewRequest(http.MethodPost, route.GetAllPath, strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf(ErrNewRequest, err)
+			}
+			request.Header.Set(ContentType, ApplicationJSON)
+
+			// Act
+			router.ServeHTTP(recorder, request)
+
+			// Assert
+			assert.Equal(t, http.StatusUnprocessableEntity, recorder.Code)
+		})
+	}
+}
+
 // TestRequestPOSTPlayersTrailingSlashEmptyBodyResponseStatusBadRequest tests that a
 // POST request to /players/ (with trailing slash) and an empty body
 // returns a 400 Bad Request status.
 func TestRequestPOSTPlayersTrailingSlashEmptyBodyResponseStatusBadRequest(test *testing.T) {
+
 	// Arrange
 	router := setupRouter(playerController)
 	recorder := httptest.NewRecorder()
@@ -224,6 +286,7 @@ func TestRequestPOSTPlayersTrailingSlashEmptyBodyResponseStatusBadRequest(test *
 // POST request to /players when service.RetrieveBySquadNumber() returns an unexpected error
 // returns a 500 Internal Server Error status.
 func TestRequestPOSTPlayersRetrieveErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -255,6 +318,7 @@ func TestRequestPOSTPlayersRetrieveErrorResponseStatusInternalServerError(test *
 // POST request to /players when service.Create() returns an error
 // returns a 500 Internal Server Error status.
 func TestRequestPOSTPlayersCreateErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -289,6 +353,7 @@ func TestRequestPOSTPlayersCreateErrorResponseStatusInternalServerError(test *te
 // POST request to /players when service.Create() returns a unique constraint
 // error (concurrent insert race) returns a 409 Conflict status.
 func TestRequestPOSTPlayersCreateErrorResponseStatusConflict(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -329,6 +394,7 @@ func TestRequestPOSTPlayersCreateErrorResponseStatusConflict(test *testing.T) {
 // GET request to /players/ (with trailing slash)
 // returns a 200 OK status.
 func TestRequestGETPlayersTrailingSlashResponseStatusOK(test *testing.T) {
+
 	// Arrange
 	router := setupRouter(playerController)
 	recorder := httptest.NewRecorder()
@@ -348,6 +414,7 @@ func TestRequestGETPlayersTrailingSlashResponseStatusOK(test *testing.T) {
 // GET request to /players
 // returns a 200 OK status.
 func TestRequestGETPlayersResponseStatusOK(test *testing.T) {
+
 	// Arrange
 	router := setupRouter(playerController)
 	recorder := httptest.NewRecorder()
@@ -367,6 +434,7 @@ func TestRequestGETPlayersResponseStatusOK(test *testing.T) {
 // GET request to /players
 // returns a collection of Players.
 func TestRequestGETPlayersResponsePlayers(test *testing.T) {
+
 	// Arrange
 	router := setupRouter(playerController)
 	recorder := httptest.NewRecorder()
@@ -390,6 +458,7 @@ func TestRequestGETPlayersResponsePlayers(test *testing.T) {
 // GET request to /players when service.RetrieveAll() returns an unexpected error
 // returns a 500 Internal Server Error status.
 func TestRequestGETPlayersRetrieveErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveAllFunc: func() ([]model.Player, error) {
@@ -417,6 +486,7 @@ func TestRequestGETPlayersRetrieveErrorResponseStatusInternalServerError(test *t
 // GET request to /players/:id when the UUID is absent from the database
 // returns a 404 Not Found status.
 func TestRequestGETPlayerByIDUnknownResponseStatusNotFound(test *testing.T) {
+
 	// Arrange
 	player := MakeUnknownPlayer()
 	router := setupRouter(playerController)
@@ -437,6 +507,7 @@ func TestRequestGETPlayerByIDUnknownResponseStatusNotFound(test *testing.T) {
 // GET request to /players/:id when the UUID exists
 // returns a 200 OK status.
 func TestRequestGETPlayerByIDExistingResponseStatusOK(test *testing.T) {
+
 	// Arrange
 	// Squad #10 = Lionel Messi → UUID v5 derived from "Lionel-Messi" using canonical namespace
 	id := "acc433bf-d505-51fe-831e-45eb44c4d43c"
@@ -458,6 +529,7 @@ func TestRequestGETPlayerByIDExistingResponseStatusOK(test *testing.T) {
 // GET request to /players/:id when the UUID exists
 // returns a matching Player.
 func TestRequestGETPlayerByIDExistingResponsePlayer(test *testing.T) {
+
 	// Arrange
 	// Squad #10 = Lionel Messi → UUID v5 derived from "Lionel-Messi" using canonical namespace
 	id := "acc433bf-d505-51fe-831e-45eb44c4d43c"
@@ -486,6 +558,7 @@ func TestRequestGETPlayerByIDExistingResponsePlayer(test *testing.T) {
 // GET request to /players/:id when service.RetrieveByID() returns an unexpected error
 // returns a 500 Internal Server Error status.
 func TestRequestGETPlayerByIDRetrieveErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveByIDFunc: func(id string) (model.Player, error) {
@@ -540,6 +613,7 @@ func TestRequestGETPlayerBySquadNumber(test *testing.T) {
 // GET request to /players/squadnumber/:squadnumber when the squad number exists
 // returns a matching Player.
 func TestRequestGETPlayerBySquadNumberExistingResponsePlayer(test *testing.T) {
+
 	// Arrange
 	squadNumber := "10"
 	router := setupRouter(playerController)
@@ -570,6 +644,7 @@ func TestRequestGETPlayerBySquadNumberExistingResponsePlayer(test *testing.T) {
 // GET request to /players/squadnumber/:squadnumber when service.RetrieveBySquadNumber() returns an unexpected error
 // returns a 500 Internal Server Error status.
 func TestRequestGETPlayerBySquadNumberRetrieveErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -597,6 +672,7 @@ func TestRequestGETPlayerBySquadNumberRetrieveErrorResponseStatusInternalServerE
 // PUT request to /players/squadnumber/:squadnumber with an empty body
 // returns a 400 Bad Request status.
 func TestRequestPUTPlayerBySquadNumberEmptyBodyResponseStatusBadRequest(test *testing.T) {
+
 	// Arrange
 	squadNumber := "23"
 	router := setupRouter(playerController)
@@ -618,6 +694,7 @@ func TestRequestPUTPlayerBySquadNumberEmptyBodyResponseStatusBadRequest(test *te
 // PUT request to /players/squadnumber/:squadnumber when the squad number is absent from the database
 // returns a 404 Not Found status.
 func TestRequestPUTPlayerBySquadNumberUnknownResponseStatusNotFound(test *testing.T) {
+
 	// Arrange
 	player := MakeUnknownPlayer()
 	squadNumber := fmt.Sprintf("%d", player.SquadNumber)
@@ -644,6 +721,7 @@ func TestRequestPUTPlayerBySquadNumberUnknownResponseStatusNotFound(test *testin
 // PUT request to /players/squadnumber/:squadnumber when the squad number is invalid (non-numeric)
 // returns a 400 Bad Request status.
 func TestRequestPUTPlayerBySquadNumberInvalidParamResponseStatusBadRequest(test *testing.T) {
+
 	// Arrange
 	squadNumber := InvalidSquadNumber
 	player := MakeExistingPlayer()
@@ -670,6 +748,7 @@ func TestRequestPUTPlayerBySquadNumberInvalidParamResponseStatusBadRequest(test 
 // PUT request to /players/squadnumber/:squadnumber with an existing player
 // returns a 204 No Content status.
 func TestRequestPUTPlayerBySquadNumberExistingResponseStatusNoContent(test *testing.T) {
+
 	// Arrange
 	squadNumber := "23"
 	player := MakeUpdatePlayer()
@@ -704,6 +783,7 @@ func TestRequestPUTPlayerBySquadNumberExistingResponseStatusNoContent(test *test
 // PUT request to /players/squadnumber/:squadnumber when the squad number in the URL
 // does not match the one in the request body returns a 400 Bad Request status.
 func TestRequestPUTPlayerBySquadNumberMismatchSquadNumberResponseStatusBadRequest(test *testing.T) {
+
 	// Arrange
 	player := MakeExistingPlayer() // SquadNumber == 23
 	player.SquadNumber = 99        // mismatch: URL targets /players/squadnumber/23, body carries 99
@@ -726,10 +806,73 @@ func TestRequestPUTPlayerBySquadNumberMismatchSquadNumberResponseStatusBadReques
 	assert.Equal(test, http.StatusBadRequest, recorder.Code)
 }
 
+// TestRequestPUTPlayerBySquadNumberValidationResponseStatusUnprocessableEntity tests that a
+// PUT request to /players/squadnumber/:squadnumber with an invalid payload
+// (missing required fields or out-of-range squadNumber) returns a
+// 422 Unprocessable Entity status.
+func TestRequestPUTPlayerBySquadNumberValidationResponseStatusUnprocessableEntity(test *testing.T) {
+	cases := []struct {
+		name        string
+		squadNumber string
+		body        string
+	}{
+		{
+			"MissingRequiredFieldResponseStatusUnprocessableEntity",
+			"23",
+			func() string {
+				p := MakeUpdatePlayer()
+				p.FirstName = ""
+				b, _ := json.Marshal(p)
+				return string(b)
+			}(),
+		},
+		{
+			"SquadNumberBelowMinResponseStatusUnprocessableEntity",
+			"23",
+			func() string {
+				p := MakeUpdatePlayer()
+				p.SquadNumber = 0
+				b, _ := json.Marshal(p)
+				return string(b)
+			}(),
+		},
+		{
+			"SquadNumberAboveMaxResponseStatusUnprocessableEntity",
+			"23",
+			func() string {
+				p := MakeUpdatePlayer()
+				p.SquadNumber = 100
+				b, _ := json.Marshal(p)
+				return string(b)
+			}(),
+		},
+	}
+	for _, tc := range cases {
+		test.Run(tc.name, func(t *testing.T) {
+
+			// Arrange
+			router := setupRouter(playerController)
+			recorder := httptest.NewRecorder()
+			request, err := http.NewRequest(http.MethodPut, buildSquadNumberPath(tc.squadNumber), strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf(ErrNewRequest, err)
+			}
+			request.Header.Set(ContentType, ApplicationJSON)
+
+			// Act
+			router.ServeHTTP(recorder, request)
+
+			// Assert
+			assert.Equal(t, http.StatusUnprocessableEntity, recorder.Code)
+		})
+	}
+}
+
 // TestRequestPUTPlayerBySquadNumberRetrieveErrorResponseStatusInternalServerError tests that a
 // PUT request to /players/squadnumber/:squadnumber when service.RetrieveBySquadNumber() returns an unexpected error
 // returns a 500 Internal Server Error status.
 func TestRequestPUTPlayerBySquadNumberRetrieveErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -761,6 +904,7 @@ func TestRequestPUTPlayerBySquadNumberRetrieveErrorResponseStatusInternalServerE
 // PUT request to /players/squadnumber/:squadnumber when service.Update() returns an error
 // returns a 500 Internal Server Error status.
 func TestRequestPUTPlayerBySquadNumberUpdateErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -826,6 +970,7 @@ func TestRequestDELETEPlayerBySquadNumber(test *testing.T) {
 // shared in-memory DB. The test first POSTs Lo Celso (accepting 201 or 409 in case
 // a prior test already inserted him) then DELETEs squad 27.
 func TestRequestDELETEPlayerBySquadNumberExistingResponseStatusNoContent(test *testing.T) {
+
 	// Arrange
 	player := MakeNonexistentPlayer()
 	body, err := json.Marshal(player)
@@ -861,6 +1006,7 @@ func TestRequestDELETEPlayerBySquadNumberExistingResponseStatusNoContent(test *t
 // DELETE request to /players/squadnumber/:squadnumber when service.RetrieveBySquadNumber() returns an unexpected error
 // returns a 500 Internal Server Error status.
 func TestRequestDELETEPlayerBySquadNumberRetrieveErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {
@@ -886,6 +1032,7 @@ func TestRequestDELETEPlayerBySquadNumberRetrieveErrorResponseStatusInternalServ
 // DELETE request to /players/squadnumber/:squadnumber when service.Delete() returns an error
 // returns a 500 Internal Server Error status.
 func TestRequestDELETEPlayerBySquadNumberDeleteErrorResponseStatusInternalServerError(test *testing.T) {
+
 	// Arrange
 	mockService := &MockPlayerService{
 		RetrieveBySquadNumberFunc: func(squadNumber int) (model.Player, error) {

--- a/tests/player_fake.go
+++ b/tests/player_fake.go
@@ -78,10 +78,20 @@ func MakeNonexistentPlayer() model.Player {
 // database. Used for 404-by-lookup scenarios (GET by ID, PUT/DELETE by squad number).
 // Squad 99 is chosen to be outside the seeded range and distinct from the nonexistent
 // fixture (squad 27), so the two terms remain unambiguous in test output.
+// All required fields are populated so the payload passes binding validation before
+// reaching the 404 lookup.
 func MakeUnknownPlayer() model.Player {
 	return model.Player{
-		ID:          "00000000-0000-4000-8000-000000000000",
-		SquadNumber: 99,
+		ID:           "00000000-0000-4000-8000-000000000000",
+		FirstName:    "Unknown",
+		LastName:     "Player",
+		DateOfBirth:  "2000-01-01T00:00:00.000Z",
+		SquadNumber:  99,
+		Position:     "Forward",
+		AbbrPosition: "FW",
+		Team:         "Unknown FC",
+		League:       "Unknown League",
+		Starting11:   false,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `binding` struct tags to `Player` for field-level validation (`required` on 7 string fields, `min=1,max=99` on `squadNumber`, `omitempty` on `middleName`, `binding:"-"` on `ID`)
- Replaces `BindJSON` with `ShouldBindJSON` in POST and PUT handlers; uses `errors.As(err, &validator.ValidationErrors{})` to return `422 Unprocessable Entity` for validation failures and `400 Bad Request` for malformed JSON
- Adds `@Failure 422` Swagger annotations on POST and PUT; regenerates docs
- Adds `TestRequestPOSTPlayersValidationResponseStatusUnprocessableEntity` and `TestRequestPUTPlayerBySquadNumberValidationResponseStatusUnprocessableEntity` (3 subtests each); updates `MakeUnknownPlayer()` to carry all required fields

Closes #257
Closes #253

## Test plan

- [x] All 38 tests pass (`go test ./...`)
- [x] Coverage: 100% across `service`, `controller`, `route`
- [x] `go vet` and `golangci-lint` clean
- [x] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/259)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced validation on player endpoints: required fields (name, position, team, league, date of birth) and squad number range constraints (1-99).

* **Bug Fixes**
  * Improved API error responses: validation failures now return 422 (Unprocessable Entity) instead of 400 (Bad Request), providing clearer error distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->