### PR TITLE
docs(changelog): remove How to Release prose section (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This project uses famous football player names (A-Z) as release codenames:
 ### Removed
 
 - `gorm.io/driver/sqlite` and `github.com/mattn/go-sqlite3` removed from the dependency graph (`go mod tidy`) (#237)
+- `CHANGELOG.md`: removed `## How to Release` prose section — release procedure belongs in `RELEASES.md`, not the changelog (#252)
 
 ### Fixed
 
@@ -187,17 +188,6 @@ Run them only when you need to recreate the local SQLite database.
 ## [1.0.0 - Ademir] - 2026-02-06
 
 Initial release. See [README.md](README.md) for complete feature list and documentation.
-
----
-
-## How to Release
-
-The full release procedure — branch, PR, tag, and CD workflow — is documented in
-[README.md § Create a Release](README.md#create-a-release).
-
-In summary: move items from `[Unreleased]` to a new `[X.Y.Z - Player]` section
-(see template below), open a `release/vX.Y.Z-player` PR, merge it into `master`,
-then push the annotated tag to trigger the CD workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the `## How to Release` prose block from `CHANGELOG.md`
- Keeps the `<!-- Template for new releases: -->` comment, trailing `---` separator, and reference links unchanged

## Test plan

- [x] Verify `## How to Release` heading and prose are gone
- [x] Verify `<!-- Template for new releases: -->` comment is intact
- [x] Verify reference links at the bottom are unchanged

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/263)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified CHANGELOG.md by moving release procedure documentation to README, streamlining the changelog to focus on version history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->