### PR TITLE
chore(go): upgrade Go from 1.25.0 to 1.26.2 (#266)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 # https://docs.coderabbit.ai/getting-started/configure-coderabbit
 
 # CodeRabbit Configuration
-# Optimized for Go 1.25 / Gin RESTful API project
+# Optimized for Go 1.26 / Gin RESTful API project
 
 language: en-US
 early_access: true
@@ -120,7 +120,7 @@ reviews:
     - path: "**/Dockerfile"
       instructions: |
         - Verify multi-stage build (builder + runtime)
-        - Check Go version matches project (1.25)
+        - Check Go version matches project (1.26)
         - Ensure CGO dependencies are installed (gcc, musl-dev, sqlite-dev)
         - Validate non-root user is used for security
         - Check HEALTHCHECK instruction is present
@@ -128,7 +128,7 @@ reviews:
 
     - path: "go.mod"
       instructions: |
-        - Verify Go version is 1.25
+        - Verify Go version is 1.26
         - Check dependencies are up to date
         - Ensure replace directives are justified
         - Validate module path is correct

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ REST API for managing football players built with Go and Gin Web Framework. Impl
 
 ## Tech Stack
 
-- **Language**: Go 1.25+
+- **Language**: Go 1.26+
 - **Framework**: Gin Web Framework
 - **ORM**: GORM
 - **Database**: SQLite

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -10,7 +10,7 @@ on:
       - "v*.*.*-*"
 
 env:
-  GO_VERSION: 1.25.0
+  GO_VERSION: 1.26.2
   PKG_SERVICE: "github.com/nanotaboada/go-samples-gin-restful/service"
   PKG_CONTROLLER: "github.com/nanotaboada/go-samples-gin-restful/controller"
   PKG_ROUTE: "github.com/nanotaboada/go-samples-gin-restful/route"

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,7 +10,7 @@ on:
     branches: [ "master" ]
 
 env:
-  GO_VERSION: 1.25.0
+  GO_VERSION: 1.26.2
   PKG_SERVICE: "github.com/nanotaboada/go-samples-gin-restful/service"
   PKG_CONTROLLER: "github.com/nanotaboada/go-samples-gin-restful/controller"
   PKG_ROUTE: "github.com/nanotaboada/go-samples-gin-restful/route"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This project uses famous football player names (A-Z) as release codenames:
 
 ### Changed
 
+- Upgraded Go from `1.25.0` to `1.26.2` in `go.mod`, CI/CD workflows, and `Dockerfile` (#266)
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ This project uses famous football player names (A-Z) as release codenames:
 
 ### Changed
 
-- Upgraded Go from `1.25.0` to `1.26.2` in `go.mod`, CI/CD workflows, and `Dockerfile` (#266)
+- Upgraded Go from `1.25.0` to `1.26.2` in `go.mod`, CI/CD workflows, `Dockerfile`, and all documentation references (#266)
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Builder
 # This stage builds the application and its dependencies.
 # ------------------------------------------------------------------------------
-FROM golang:1.25-alpine3.23 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 
 ENV CGO_ENABLED=0
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ![Claude](https://img.shields.io/badge/Claude-contributing-D97757?logo=claude&logoColor=white&labelColor=181818)
 ![CodeRabbit](https://img.shields.io/badge/CodeRabbit-reviewing-FF570A?logo=coderabbit&logoColor=white&labelColor=181818)
 
-Proof of Concept for a RESTful Web Service built with **Gin** and **Go 1.25**. This project demonstrates best practices for building a layered, testable, and maintainable API implementing CRUD operations for a Players resource (Argentina 2022 FIFA World Cup squad).
+Proof of Concept for a RESTful Web Service built with **Gin** and **Go 1.26**. This project demonstrates best practices for building a layered, testable, and maintainable API implementing CRUD operations for a Players resource (Argentina 2022 FIFA World Cup squad).
 
 ## Features
 
@@ -28,7 +28,7 @@ Proof of Concept for a RESTful Web Service built with **Gin** and **Go 1.25**. T
 
 | Category | Technology |
 | -------- | ---------- |
-| **Language** | [Go 1.25](https://github.com/golang/go) |
+| **Language** | [Go 1.26](https://github.com/golang/go) |
 | **Web Framework** | [Gin](https://github.com/gin-gonic/gin) |
 | **ORM** | [GORM](https://github.com/go-gorm/gorm) |
 | **Database** | [SQLite](https://github.com/sqlite/sqlite) |
@@ -143,7 +143,7 @@ Alternatively, use [`rest/players.rest`](rest/players.rest) with the [REST Clien
 
 Before you begin, ensure you have the following installed:
 
-- **Go 1.25 or higher**
+- **Go 1.26 or higher**
 - **Docker & Docker Compose** (optional, for containerized deployment)
 
 ## Quick Start

--- a/docs/adr/0011-docker-and-compose-strategy.md
+++ b/docs/adr/0011-docker-and-compose-strategy.md
@@ -40,7 +40,7 @@ Available approaches:
 We will use a multi-stage Docker build with an Alpine-based runtime, and
 Docker Compose to orchestrate the application locally.
 
-- **Builder stage** (`golang:1.25-alpine3.23`): installs `gcc`,
+- **Builder stage** (`golang:1.26-alpine3.23`): installs `gcc`,
   `musl-dev`, and `sqlite-dev` to satisfy CGO dependencies; builds the
   binary with `-trimpath -ldflags="-s -w"` to strip debug symbols and
   reduce size; uses `--mount=type=cache` for the Go module and build caches

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nanotaboada/go-samples-gin-restful
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/gin-gonic/gin v1.12.0


### PR DESCRIPTION
## Summary

- Upgraded Go from `1.25.0` to `1.26.2` in `go.mod`, `Dockerfile`, and both CI/CD workflow files
- Unblocks Dependabot PRs (e.g. #264) that transitively require Go ≥ 1.25.7
- `golang:1.26-alpine` ships Go 1.26.2 on Alpine 3.23.4 — same Alpine minor as before

## Test plan

- [x] All CI jobs pass (lint, build, test, coverage)
- [x] `docker compose build` succeeds locally (verified)
- [x] No regressions in existing tests (100% coverage on service, controller, route)

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/267)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain from version 1.25.0 to 1.26.2 across build, test, and deployment environments to leverage the latest language improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->