### PR TITLE
docs(adr): add themed versioning, AI workflow and SDD records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,14 @@ This project uses famous football player names (A-Z) as release codenames:
 
 ### Added
 
+- ADR-0013: Use Player-Themed Semantic Versioning
+- ADR-0014: Adopt AI-Assisted Development Workflow
+- ADR-0015: Adopt Spec-Driven Development (SDD)
+
 ### Changed
 
 - Updated `CLAUDE.md`: added missing directories (`/migrations`, `/swagger`, `/tools`, `/rest`) to the structure map, corrected `/storage` entry, expanded test naming condition/outcome lists, and documented the `embed.FS` migration pattern and `//go:build ignore` seed tools
+- Added `go mod tidy` as a sequential pre-build gate in the `/pre-commit` checklist to catch dependency drift before push
 - Upgraded Go from `1.25.0` to `1.26.2` in `go.mod`, CI/CD workflows, `Dockerfile`, and all documentation references (#266)
 - Consolidated project documentation into `CLAUDE.md` as the single source of truth; deleted `.github/copilot-instructions.md`; updated `README.md` Contributing section to reference `CLAUDE.md` (#272)
 - Updated `.coderabbit.yaml`: added pure-Go SQLite constraint to `go.mod` path instruction (ADR-0012), strengthened mock policy in `tests/**/*.go` instruction (ADR-0010), corrected controller HTTP status code list to include 400 and 500, and updated `knowledge_base` file reference to `CLAUDE.md` (#272)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 
 ## Architecture Decision Records
 
-Significant architectural decisions are documented in `docs/adr/` (ADR-0001–ADR-0012). Load these before proposing structural changes. When a proposal would change an accepted decision, create a new ADR rather than editing the existing one.
+Significant architectural decisions are documented in `docs/adr/` (ADR-0001–ADR-0015). Load these before proposing structural changes. When a proposal would change an accepted decision, create a new ADR rather than editing the existing one.
 
 ## Claude Code
 

--- a/docs/adr/0013-player-themed-versioning.md
+++ b/docs/adr/0013-player-themed-versioning.md
@@ -1,0 +1,76 @@
+# ADR-0013: Use Player-Themed Semantic Versioning
+
+Date: 2026-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+The project uses Semantic Versioning (MAJOR.MINOR.PATCH). Purely numeric tags
+are accurate but forgettable. The project is football-themed and part of a
+cross-language comparison set where each repo adopts a different
+football-domain naming convention. Several well-known projects use alphabetical
+codename conventions (Ubuntu, macOS).
+
+Release tags follow the format `v{MAJOR}.{MINOR}.{PATCH}-{player}`, where the
+player name is drawn from the fixed list below, assigned A→Z sequentially:
+
+| Letter | Player Name | Country/Era | Tag Name |
+| ------ | ----------- | ----------- | -------- |
+| A | Ademir | Brazil | `ademir` |
+| B | Bobby (Moore) | England | `bobby` |
+| C | Cafu | Brazil | `cafu` |
+| D | (Alfredo) Di Stéfano | Argentina/Spain | `distefano` |
+| E | Eusébio | Portugal | `eusebio` |
+| F | Franz (Beckenbauer) | Germany | `franz` |
+| G | Garrincha | Brazil | `garrincha` |
+| H | (Thierry) Henry | France | `henry` |
+| I | (Filippo) Inzaghi | Italy | `inzaghi` |
+| J | Jairzinho | Brazil | `jairzinho` |
+| K | (Roy) Keane | Ireland | `keane` |
+| L | (Frank) Lampard | England | `lampard` |
+| M | (Diego) Maradona | Argentina | `maradona` |
+| N | Nilton (Santos) | Brazil | `nilton` |
+| O | (Jay-Jay) Okocha | Nigeria | `okocha` |
+| P | Pelé | Brazil | `pele` |
+| Q | (Fabio) Quagliarella | Italy | `quagliarella` |
+| R | Romário | Brazil | `romario` |
+| S | (Paul) Scholes | England | `scholes` |
+| T | (Francesco) Totti | Italy | `totti` |
+| U | Uwe (Seeler) | Germany | `uwe` |
+| V | (Patrick) Vieira | France | `vieira` |
+| W | (Ian) Wright | England | `wright` |
+| X | Xabi (Alonso) | Spain | `xabi` |
+| Y | (Lev) Yashin | USSR | `yashin` |
+| Z | Zico | Brazil | `zico` |
+
+## Decision
+
+Every release tag appends an alphabetically ordered footballer surname to the
+Semantic Version. Format: `v{MAJOR}.{MINOR}.{PATCH}-{player}`. Names are drawn
+from the fixed list above, assigned A→Z sequentially. The CD pipeline validates
+the name before publishing.
+
+## Consequences
+
+**Positive:**
+
+- Release names are memorable and human-friendly.
+- Alphabetical ordering provides an implicit sequence visible in `git tag`.
+- The naming scheme is deterministic — the next name is always the next letter.
+- Reinforces the football theme across the cross-language comparison set.
+
+**Negative:**
+
+- Non-standard tag format; may confuse new contributors unfamiliar with the
+  convention.
+- The list is finite — 26 slots before the sequence must restart or be
+  extended.
+- CD validation adds a small amount of pipeline complexity.
+
+**Neutral:**
+
+- The full list is published in `CHANGELOG.md`; the current position is always
+  the last released tag.

--- a/docs/adr/0014-ai-assisted-development-workflow.md
+++ b/docs/adr/0014-ai-assisted-development-workflow.md
@@ -1,0 +1,77 @@
+# ADR-0014: Adopt AI-Assisted Development Workflow
+
+Date: 2026-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+Software development has historically relied on three successive layers
+of knowledge:
+
+1. **Official documentation** — authoritative but static; describes the
+   intended API but not how real projects apply it
+2. **Community collaboration** — Stack Overflow, GitHub Discussions, blog
+   posts; describes how practitioners actually solve problems, but requires
+   the developer to synthesize and apply that knowledge themselves
+3. **AI synthesis** — models trained on both layers above, capable of
+   applying idiomatic, stack-specific knowledge directly to a given
+   codebase
+
+Agentic AI tools represent a qualitative shift: instead of consulting
+knowledge and applying it manually, the developer delegates implementation
+to an agent that has absorbed the collective idioms of a stack — "the
+Microsoft way", "the Go way", "the Gin way" — and can apply them
+consistently.
+
+For a cross-language REST API comparison project, this matters
+particularly: each implementation should reflect how an experienced
+practitioner in that stack would structure the same problem, not a
+generic approach that happens to compile.
+
+Prior to Claude Code, AI assistance was used ad-hoc — pasting code into
+web interfaces (ChatGPT, DeepSeek) or via IDE-integrated assistants
+(GitHub Copilot). Both approaches lack persistent codebase context and
+the ability to act autonomously across a project.
+
+## Decision
+
+We adopt Claude Code as the primary development workflow tool for this
+project.
+
+A `CLAUDE.md` file at the repository root serves as the workflow
+specification: it documents architecture, coding conventions, invariants,
+and explicit boundaries for autonomous operation — what the agent may do
+freely, what requires human approval, and what must never be changed.
+
+CodeRabbit provides an additional automated code review layer
+independent of the primary workflow.
+
+## Consequences
+
+**Positive:**
+
+- Stack-specific idioms are enforced by the agent's collective knowledge
+  rather than individual developer discipline
+- `CLAUDE.md` is living architectural documentation: it must stay
+  accurate for the workflow to function, creating a natural incentive to
+  keep it current
+- Explicit autonomy boundaries make human oversight intentional rather
+  than incidental
+
+**Negative:**
+
+- Token economics: long-running work may exceed context limits, requiring
+  active session management and continuation prompts to resume work
+  across sessions
+- The global `~/.claude/CLAUDE.md` and per-repo `CLAUDE.md` must stay
+  aligned; drift between them produces inconsistent agent behavior
+
+**Neutral:**
+
+- Development workflow moves to the terminal/CLI rather than an IDE;
+  this has no impact on the codebase itself
+- `CLAUDE.md` is specific to Claude Code; a different tool would require
+  a different workflow specification format

--- a/docs/adr/0015-spec-driven-development.md
+++ b/docs/adr/0015-spec-driven-development.md
@@ -1,0 +1,61 @@
+# ADR-0015: Adopt Spec-Driven Development (SDD)
+
+Date: 2026-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+In an agentic development workflow, it is easy to begin implementation
+before requirements are fully understood. An AI assistant will produce
+working code from a vague prompt — but working and correct are not the
+same thing. Without a forcing function that requires requirements to be
+stated explicitly before implementation begins, scope creep, rework, and
+misaligned implementations are likely outcomes.
+
+GitHub Issues provide a natural spec artifact: persistent, linkable,
+and — critically — they survive session boundaries. In a workflow where
+context is lost between sessions, an Issue that captures the agreed
+approach and acceptance criteria before implementation begins serves as
+the durable contract between intent and implementation.
+
+## Decision
+
+All new features and non-trivial changes follow a three-step workflow:
+
+1. **Discuss** — describe the requirement in Claude Code Plan mode;
+   explore alternatives and consequences before committing to an approach
+2. **Specify** — create a GitHub Issue as the spec artifact, capturing
+   the agreed approach, acceptance criteria, and any constraints
+3. **Implement** — work against the Issue; commits reference it via
+   the `(#issue)` suffix in the Conventional Commits format
+
+Trivial changes (documentation updates, formatting fixes, dependency
+bumps) may skip the Issue step at the developer's discretion.
+
+## Consequences
+
+**Positive:**
+
+- Requirements are stated explicitly before implementation; the agent
+  works against a written spec rather than an interpreted prompt
+- Issues survive session boundaries — a new session can resume from
+  the Issue rather than reconstructing intent from scratch
+- The implementation trail (Issue → branch → PR → commit) is traceable
+  without relying on session memory
+
+**Negative:**
+
+- Adds upfront overhead for changes that feel small; the Issue step can
+  seem bureaucratic for straightforward work
+- The line between "spec-worthy" and "trivial" is judgment-dependent
+  and not enforced by tooling
+
+**Neutral:**
+
+- GitHub Issues double as the project backlog; SDD and backlog
+  management share the same artifact
+- Plan mode discussion is ephemeral — not persisted outside the session;
+  the Issue is the only durable record of the pre-implementation reasoning

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,6 @@ See [template.md](template.md) for the standard format (Michael Nygard).
 | [0010](0010-mixed-test-strategy.md) | Mixed Test Strategy | Accepted | 2026-03-21 |
 | [0011](0011-docker-and-compose-strategy.md) | Docker and Compose Strategy | Accepted | 2026-04-02 |
 | [0012](0012-pure-go-sqlite-driver.md) | Pure-Go SQLite Driver | Accepted | 2026-04-20 |
+| [0013](0013-player-themed-versioning.md) | Use Player-Themed Semantic Versioning | Accepted | 2026-06-10 |
+| [0014](0014-ai-assisted-development-workflow.md) | Adopt AI-Assisted Development Workflow | Accepted | 2026-06-10 |
+| [0015](0015-spec-driven-development.md) | Adopt Spec-Driven Development (SDD) | Accepted | 2026-06-10 |


### PR DESCRIPTION
## Summary

- ADR-0013: Documents the player-themed semantic versioning convention (`v{SEMVER}-{player}`, A→Z) including the full 26-name footballer list and CD validation rationale
- ADR-0014: Documents the adoption of Claude Code as the primary AI-assisted development workflow, with `CLAUDE.md` as the living workflow specification
- ADR-0015: Documents the Spec-Driven Development (SDD) workflow — Discuss → Specify (GitHub Issue) → Implement

Also updates `docs/adr/README.md` index, `CHANGELOG.md` `[Unreleased]` section, and the ADR range reference in `CLAUDE.md` (0001–0012 → 0001–0015).

## Test plan

- [ ] All three ADR files render correctly on GitHub
- [ ] `docs/adr/README.md` index links resolve to the correct files
- [ ] `CHANGELOG.md` `[Unreleased]` → Added section contains all three entries
- [ ] `CLAUDE.md` ADR range updated to ADR-0001–ADR-0015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/go-samples-gin-restful/278)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Records documenting player-themed semantic versioning, AI-assisted development workflow adoption, and spec-driven development practices.
  * Updated development guidelines reference documentation.

* **Chores**
  * Added dependency validation check to pre-commit gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->